### PR TITLE
Fixed crash in NotificationCallback after unregister

### DIFF
--- a/src/WinBleLib/BleGattCharacteristic.h
+++ b/src/WinBleLib/BleGattCharacteristic.h
@@ -50,7 +50,7 @@ class BleGattCharacteristic
 
 		USHORT _gattDescriptorsCount = 0;
 
-		CallbackContext* _callbackContext;
+		CallbackContext _callbackContext;
 
 		BleDeviceContext& _bleDeviceContext;
 
@@ -160,7 +160,8 @@ class BleGattCharacteristic
 		void registerNotificationHandler(function<void(BleGattNotificationData&)> notificationHandler);
 
 		/// <summary>
-		/// Unregister the notification callback for this <see cref="BleGattCharacteristic"/> and start notifications
+		/// Unregister the notification callback for this <see cref="BleGattCharacteristic"/> and end notifications
+		/// After this function returns, no more callbacks will be invoked.
 		/// </summary>
 		/// <remarks></remarks>
 		void unregisterNotificationHandler();

--- a/src/WinBleLib/CallbackScope.h
+++ b/src/WinBleLib/CallbackScope.h
@@ -1,0 +1,53 @@
+/*
+MIT License
+
+Copyright(c) Derek Goslin 2017
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#pragma once
+
+#include "CallbackContext.h"
+
+// CallbackScope sets invokes CallbackContext.SetInCallback in its constructor
+// and invokes CallbackContext.UnsetInCallback in its destructor
+
+class CallbackScope
+{
+public:
+	CallbackScope(CallbackScope&&) = delete;
+	CallbackScope(const CallbackScope&) = delete;
+	CallbackScope& operator=(const CallbackScope&) = delete;
+	CallbackScope& operator=(CallbackScope&&) = delete;
+
+	CallbackScope(CallbackContext& context) : _context(context)
+	{
+		_context.SetInCallback();
+	}
+
+	~CallbackScope()
+	{
+		_context.UnsetInCallback();
+	}
+
+private:
+	CallbackContext& _context;
+};

--- a/src/WinBleLib/WinBleLib.vcxproj
+++ b/src/WinBleLib/WinBleLib.vcxproj
@@ -158,6 +158,7 @@
     <ClInclude Include="BleGattService.h" />
     <ClInclude Include="BleGattServices.h" />
     <ClInclude Include="CallbackContext.h" />
+    <ClInclude Include="CallbackScope.h" />
     <ClInclude Include="FileHandleWrapper.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="targetver.h" />

--- a/src/WinBleLib/WinBleLib.vcxproj.filters
+++ b/src/WinBleLib/WinBleLib.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClInclude Include="FileHandleWrapper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CallbackScope.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BleDevice.cpp">


### PR DESCRIPTION
The PR has three parts:
- _callbackContext is no longer allocated on the heap because it cannot be deleted safely neither in unregisterNotificationHandler nor in NotificationCallback. Now it is a member of BleGattCharacteristic
- The registration state is set by unregisterNotificationHandler and read by NotificationCallback and is therefore protected by a mutex.
- An additional feature (CallbackScope) not directly related to the crash is that unregisterNotificationHandler will wait until any pending callback completes. Without this we can only guarantee that after unregisterNotificationHandler is called no new callbacks will be **scheduled**, but we cannot guarantee that the a new callback will not be **called**. This feature ensures both.